### PR TITLE
Update GXContentBuilder.groovy

### DIFF
--- a/src/groovy/org/grails/plugins/elasticsearch/util/GXContentBuilder.groovy
+++ b/src/groovy/org/grails/plugins/elasticsearch/util/GXContentBuilder.groovy
@@ -59,7 +59,7 @@ class GXContentBuilder extends GroovyObjectSupport {
         XContentBuilder builder = XContentFactory.contentBuilder(contentType)
         def json = build(c)
         builder.map(json)
-        return builder.copiedBytes()
+        return builder.bytes().toBytes()
     }
 
     private buildRoot(Closure c) {


### PR DESCRIPTION
copiedBytes() not available in elasticsearch 0.90.5, API changed (since elasticsearch 0.19.x)
