### PR TITLE
add path.plugins configuration property when building client node

### DIFF
--- a/src/docs/guide/2. Configuration.gdoc
+++ b/src/docs/guide/2. Configuration.gdoc
@@ -94,6 +94,9 @@ If this setting is not specified, 500 will be use by default.
 * @elasticSearch.path.data@
 The location of the data files of each index / shard allocated on the node.
 
+* @elasticSearch.path.plugins@
+The location of plugin files such as native scripts. Each plugin will be contained in a subdirectory.
+
 h4. Default configuration script
 Below is the default configuration loaded by the plugin (any of your settings in the Config.groovy script overwrite those).
 

--- a/src/groovy/org/grails/plugins/elasticsearch/ClientNodeFactoryBean.groovy
+++ b/src/groovy/org/grails/plugins/elasticsearch/ClientNodeFactoryBean.groovy
@@ -108,6 +108,12 @@ class ClientNodeFactoryBean implements FactoryBean {
                         nb.settings().put("index.queryparser.types.${type}".toString(), clz)
                     }
                 }
+
+                def pluginsDirectory = elasticSearchContextHolder.config.path.plugins
+                if(pluginsDirectory){
+                    nb.settings().put('path.plugins', pluginsDirectory as String)
+                }
+
                 nb.local(true)
                 break
 


### PR DESCRIPTION
Hi.

Added the path.plugins configuration property in test environment. This is needed in order to test native scripts.
