### PR TITLE
Fix for JSONObject marshalling.

### DIFF
--- a/ElasticsearchGormGrailsPlugin.groovy
+++ b/ElasticsearchGormGrailsPlugin.groovy
@@ -37,7 +37,7 @@ class ElasticsearchGormGrailsPlugin {
 
     private static final Logger LOG = LoggerFactory.getLogger(this)
 
-    def version = '0.0.2.4'
+    def version = '0.0.2.5'
     def grailsVersion = '2.1.0 > *'
 
     def loadAfter = ['services']

--- a/grails-app/domain/test/Product.groovy
+++ b/grails-app/domain/test/Product.groovy
@@ -1,10 +1,13 @@
 package test
 
+import org.codehaus.groovy.grails.web.json.JSONObject
+
 class Product {
     String name
     String description = "A description of a product"
     Float price = 1.00
     Date date
+    JSONObject json
 
     static searchable = true
 
@@ -13,9 +16,11 @@ class Product {
         description nullable: true
         price nullable: true
         date nullable: true
+        json nullable: true
     }
 
     static mapping = {
         autoImport(false)
+        json type: JsonUserType
     }
 }

--- a/src/groovy/org/grails/plugins/elasticsearch/conversion/JSONDomainFactory.groovy
+++ b/src/groovy/org/grails/plugins/elasticsearch/conversion/JSONDomainFactory.groovy
@@ -94,13 +94,16 @@ class JSONDomainFactory {
         if (!marshaller) {
             // TODO : support user custom marshaller/converter (& marshaller registration)
             // Check for domain classes
-            def propertyMapping = elasticSearchContextHolder.getMappingContext(getDomainClass(marshallingContext.peekDomainObject()))?.getPropertyMapping(marshallingContext.lastParentPropertyName)
-            if (propertyMapping?.isGeoPoint()) {
-                marshaller = new GeoPointMarshaller()
-            } else if (DomainClassArtefactHandler.isDomainClass(objectClass)) {
+            if (DomainClassArtefactHandler.isDomainClass(objectClass)) {
                 /*def domainClassName = objectClass.simpleName.substring(0,1).toLowerCase() + objectClass.simpleName.substring(1)
              SearchableClassPropertyMapping propMap = elasticSearchContextHolder.getMappingContext(domainClassName).getPropertyMapping(marshallingContext.lastParentPropertyName)*/
-                marshaller = new DeepDomainClassMarshaller()
+                 def propertyMapping = elasticSearchContextHolder.getMappingContext(getDomainClass(marshallingContext.peekDomainObject()))?.getPropertyMapping(marshallingContext.lastParentPropertyName)
+
+                 if (propertyMapping?.isGeoPoint()) {
+                     marshaller = new GeoPointMarshaller()
+                 } else {
+                     marshaller = new DeepDomainClassMarshaller()
+                 }
             } else {
                 // Check for inherited marshaller matching
                 def inheritedMarshaller = DEFAULT_MARSHALLERS.find { key, value -> key.isAssignableFrom(objectClass) }

--- a/src/groovy/test/JsonUserType.groovy
+++ b/src/groovy/test/JsonUserType.groovy
@@ -1,0 +1,62 @@
+package test
+
+import grails.converters.JSON
+import org.codehaus.groovy.grails.web.json.JSONElement
+import org.codehaus.groovy.grails.web.json.JSONObject
+import org.hibernate.usertype.UserType
+
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+import java.sql.Types
+
+class JsonUserType implements UserType {
+    int [] sqlTypes() {
+        [Types.LONGVARCHAR] as int[]
+    }
+
+    Class returnedClass() {
+        JSONObject
+    }
+
+    boolean equals(a, b) {
+        a == b
+    }
+
+    int hashCode(a) {
+        a.hashCode()
+    }
+
+    Object nullSafeGet(ResultSet resultSet, String[] names, Object owner) {
+        String str = resultSet.getString(names[0])
+        str ? JSON.parse(str) : null
+    }
+
+    void nullSafeSet(PreparedStatement preparedStatement, Object value, int index) {
+        if (value == null) {
+            preparedStatement.setNull(index, sqlTypes()[0])
+        } else {
+            JSONElement json = value as JSONElement
+            preparedStatement.setString(index, json.toString())
+        }
+    }
+
+    Object deepCopy(Object o) {
+        o
+    }
+
+    Serializable disassemble(Object o) {
+        o
+    }
+
+    Object assemble(Serializable cached, Object owner) {
+        cached
+    }
+
+    Object replace(Object original, Object target, Object owner) {
+        original
+    }
+
+    boolean isMutable() {
+        false
+    }
+}

--- a/test/integration/org/grails/plugins/elasticsearch/ElasticSearchServiceIntegrationSpec.groovy
+++ b/test/integration/org/grails/plugins/elasticsearch/ElasticSearchServiceIntegrationSpec.groovy
@@ -1,6 +1,7 @@
 package org.grails.plugins.elasticsearch
 
 import grails.plugin.spock.IntegrationSpec
+import org.codehaus.groovy.grails.web.json.JSONObject
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequestBuilder
 import org.elasticsearch.client.AdminClient
 import org.elasticsearch.client.ClusterAdminClient
@@ -76,6 +77,15 @@ class ElasticSearchServiceIntegrationSpec extends IntegrationSpec {
     void 'Indexing the same object multiple times updates the corresponding ES entry'() {
         given:
         def product = new Product(name: 'myTestProduct')
+        product.json = new JSONObject(
+                """
+{
+    "test": {
+        "details": "blah"
+    }
+}
+"""
+        )
         product.save(failOnError: true)
 
         when:


### PR DESCRIPTION
The 0.0.2.5 release broke the case where a JSONObject is an indexed field of a DomainClass. This change reorders the test for GeoPoint so that non domainClasses are not affected by th e0.0.2.5 change.
