### PR TITLE
Refactoring to grails.util.Holders for grails 2.4

### DIFF
--- a/src/groovy/org/grails/plugins/elasticsearch/util/ElasticSearchUtils.groovy
+++ b/src/groovy/org/grails/plugins/elasticsearch/util/ElasticSearchUtils.groovy
@@ -1,16 +1,16 @@
 package org.grails.plugins.elasticsearch.util
 
-import org.codehaus.groovy.grails.commons.ApplicationHolder
+import grails.util.Holders
 
 class ElasticSearchUtils {
 
     static indexDomain(entity){
-        def elasticSearchService = ApplicationHolder.application.mainContext.getBean('elasticSearchService')
+        def elasticSearchService = Holders.grailsApplication.mainContext.getBean('elasticSearchService')
         elasticSearchService.indexDomain(entity)
     }
 
     static deleteDomain(entity){
-        def elasticSearchService = ApplicationHolder.application.mainContext.getBean('elasticSearchService')
+        def elasticSearchService = Holders.grailsApplication.mainContext.getBean('elasticSearchService')
         elasticSearchService.deleteDomain(entity)
     }
 }


### PR DESCRIPTION
org.codehaus.groovy.grails.commons.ApplicationHolder is now gone in grails 2.4 and has been deprecated since 2.0 I believe.   
