### PR TITLE
Return unmatched documents too.

### DIFF
--- a/src/groovy/org/grails/plugins/elasticsearch/conversion/unmarshall/DomainClassUnmarshaller.groovy
+++ b/src/groovy/org/grails/plugins/elasticsearch/conversion/unmarshall/DomainClassUnmarshaller.groovy
@@ -56,6 +56,7 @@ class DomainClassUnmarshaller {
             SearchableClassMapping scm = elasticSearchContextHolder.findMappingContextByElasticType(type)
             if (scm == null) {
                 LOG.warn("Unknown SearchHit: ${hit.id()}#${hit.type()}")
+		results << hit.source
                 continue
             }
 


### PR DESCRIPTION
I want to use elastic search for much more than just my domains, I'm creating synthetic objects that are nice to search on, divorced from the DB itself.

This change will allow returning documents that don't match a domain class, as a Map.

Ideally, you could load in arbitrary POGOs to map to as well, but this would seem to do for now?
