### PR TITLE
Fix NPE while running application integration tests

### DIFF
--- a/ElasticsearchGrailsPlugin.groovy
+++ b/ElasticsearchGrailsPlugin.groovy
@@ -106,8 +106,7 @@ class ElasticsearchGrailsPlugin {
             grailsApplication = ref('grailsApplication')
         }
 
-        def pluginManager = application.parentContext.getBean(GrailsPluginManager.BEAN_NAME)
-        if (((GrailsPluginManager) pluginManager).hasGrailsPlugin('hibernate')) {
+        if (manager?.hasGrailsPlugin('hibernate')) {
             hibernateProxyUnWrapper(HibernateProxyUnWrapper)
         }
 


### PR DESCRIPTION
NPE is throwing when i added elasticsearch-grails-plugin to my Grails 2.4.0 project and start integration tests.
That is because `application.parentContext` is null in `doWithSpring` closure when application starts in integration test mode. Here is a quick fix for that.
