### PR TITLE
Fix for issues with lastUpdated and dateCreated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ web-app
 *.zip
 plugin.xml
 /docs
+.DS_Store

--- a/src/groovy/org/grails/plugins/elasticsearch/conversion/unmarshall/DomainClassUnmarshaller.groovy
+++ b/src/groovy/org/grails/plugins/elasticsearch/conversion/unmarshall/DomainClassUnmarshaller.groovy
@@ -115,10 +115,6 @@ class DomainClassUnmarshaller {
                     // if we tried converting the string value into a DateTime using instance."${entry.key}" = DateTime.parse(entry.value),
                     // we might run into trouble, since instance."${entry.key}" could evaluate to org.joda.DateTime, whereas
                     // DateTime.parse(entry.value) could evaluate to org.elasticsearch.DateTime
-
-
-//                instance."${entry.key}" = DateTime.parse(entry.value)
-                    //          ^^org.joda... |  ^^org.elasticsearch....
                 }
                 else if(instance.hasProperty(entry.key).type == Date && entry.value instanceof Date){
                     instance."${entry.key}" = entry.value

--- a/test/unit/org/grails/plugins/elasticsearch/conversion/unmarshall/DomainClassUnmarshallerSpec.groovy
+++ b/test/unit/org/grails/plugins/elasticsearch/conversion/unmarshall/DomainClassUnmarshallerSpec.groovy
@@ -1,0 +1,155 @@
+package org.grails.plugins.elasticsearch.conversion.unmarshall
+
+import grails.test.mixin.TestMixin
+import grails.test.mixin.web.ControllerUnitTestMixin
+import org.elasticsearch.common.joda.time.DateTime
+import spock.lang.Specification
+
+import java.text.SimpleDateFormat
+
+@TestMixin(ControllerUnitTestMixin)
+class DomainClassUnmarshallerSpec extends Specification {
+
+    DomainClassUnmarshaller unmarshaller
+
+    def setup(){
+        unmarshaller = new DomainClassUnmarshaller()
+    }
+
+    def "when instance is empty and rebuiltProperties is empty, populateUnboundDateTimeProperties sets nothing"(){
+        given:
+        def instance = new Sample()
+        def rebuiltProperties = [:]
+
+        when:
+        unmarshaller.populateUnboundDateTimeProperties(instance, rebuiltProperties)
+
+        then:
+        instance
+        !instance.identifier
+        !instance.phone
+        !instance.dateCreated
+        !instance.lastUpdated
+    }
+
+    def "when instance is empty and rebuiltProperties only has properties that do not belong to the instance, populateUnboundDateTimeProperties sets nothing"(){
+        given:
+        def instance = new Sample()
+        def rebuiltProperties = [name: "value", other: "value"]
+
+        when:
+        unmarshaller.populateUnboundDateTimeProperties(instance, rebuiltProperties)
+
+        then:
+        instance
+        !instance.identifier
+        !instance.phone
+        !instance.dateCreated
+        !instance.lastUpdated
+    }
+
+    def "when instance is empty and rebuiltProperties only has properties that are not date related, populateUnboundDateTimeProperties sets nothing"(){
+        given:
+        def instance = new Sample()
+        def rebuiltProperties = [identifier: "value", phone: "1234567890"]
+
+        when:
+        unmarshaller.populateUnboundDateTimeProperties(instance, rebuiltProperties)
+
+        then:
+        instance
+        !instance.identifier
+        !instance.phone
+        !instance.dateCreated
+        !instance.lastUpdated
+    }
+
+    def "when instance is empty and rebuiltProperties has properties that are DateTime, populateUnboundDateTimeProperties sets only those dates"(){
+        given:
+        def dateCreated = DateTime.now()
+        def lastUpdated = DateTime.now()
+        def instance = new Sample()
+        def rebuiltProperties = [identifier: "value", phone: "1234567890", dateCreated: dateCreated.toString(), lastUpdated: lastUpdated.toString()]
+
+        when:
+        unmarshaller.populateUnboundDateTimeProperties(instance, rebuiltProperties)
+
+        then:
+        instance
+        !instance.identifier
+        !instance.phone
+        dateCreated == instance.dateCreated
+        lastUpdated == instance.lastUpdated
+    }
+
+    def "when instance is empty and rebuiltProperties has properties that are DateTime and Date, populateUnboundDateTimeProperties sets both types of dates"(){
+        given:
+        def dateCreated = DateTime.now()
+        def lastUpdated = DateTime.now()
+        def lastSync = new Date()
+        def instance = new Sample()
+        def rebuiltProperties = [identifier: "value", phone: "1234567890", dateCreated: dateCreated.toString(), lastUpdated: lastUpdated.toString(), lastSync: lastSync]
+
+        when:
+        unmarshaller.populateUnboundDateTimeProperties(instance, rebuiltProperties)
+
+        then:
+        instance
+        !instance.identifier
+        !instance.phone
+        dateCreated == instance.dateCreated
+        lastUpdated == instance.lastUpdated
+        lastSync == instance.lastSync
+    }
+
+    def "when instance is empty and rebuiltProperties has null properties that are DateTime, populateUnboundDateTimeProperties sets only the non-null dates"(){
+        given:
+        def dateCreated = DateTime.now()
+        def instance = new Sample()
+        def rebuiltProperties = [identifier: "value", phone: "1234567890", dateCreated: dateCreated.toString(), lastUpdated: null]
+
+        when:
+        unmarshaller.populateUnboundDateTimeProperties(instance, rebuiltProperties)
+
+        then:
+        instance
+        !instance.identifier
+        !instance.phone
+        dateCreated == instance.dateCreated
+        !instance.lastUpdated
+    }
+
+    def "when instance is has date properties, populateUnboundDateTimeProperties does not reset them"(){
+        given:
+        def dateCreated = DateTime.now()
+        def lastUpdated = DateTime.now()
+        def lastSync = new Date()
+        def instance = new Sample(dateCreated: dateCreated, lastUpdated: lastUpdated, lastSync: lastSync)
+        def rebuiltProperties = [identifier: "value", phone: "1234567890", dateCreated: DateTime.now().toString(), lastUpdated: DateTime.now().toString()]
+
+        when:
+        unmarshaller.populateUnboundDateTimeProperties(instance, rebuiltProperties)
+
+        then:
+        instance
+        !instance.identifier
+        !instance.phone
+        dateCreated == instance.dateCreated
+        lastUpdated == instance.lastUpdated
+        lastSync == instance.lastSync
+    }
+
+
+    class Sample {
+
+        Long identifier
+        String phone
+        DateTime dateCreated
+        DateTime lastUpdated
+        Date lastSync
+
+    }
+
+}
+
+


### PR DESCRIPTION
As per the comments on https://github.com/noamt/elasticsearch-grails-plugin/issues/62 and https://github.com/grails/grails-core/issues/642, this doesn't seem to be an issue with ElasticSearch itself, seems more like an issue with DataBindingUtils on grails-core.

Anyway, I've implemented this workaround to handle Date and DateTime attributes that could not be bound by DatabindingApi. I'm not sure I've used the best approach, comments and suggestions are very welcome! :)