### PR TITLE
Support for UUID DB identifiers

### DIFF
--- a/grails-app/domain/test/Building.groovy
+++ b/grails-app/domain/test/Building.groovy
@@ -3,7 +3,7 @@ package test
 class Building {
 
     String name
-	Date date = new Date()
+    Date date = new Date()
     GeoPoint location
 
     static constraints = {
@@ -12,6 +12,6 @@ class Building {
 
     static searchable = {
         location geoPoint: true, component: true
-		date alias: "@timestamp"
+        date alias: "@timestamp"
     }
 }

--- a/grails-app/domain/test/custom/id/Toy.groovy
+++ b/grails-app/domain/test/custom/id/Toy.groovy
@@ -1,0 +1,17 @@
+package test.custom.id
+
+class Toy {
+    UUID id
+    String name
+    String color
+
+    static searchable = true
+
+    static mapping = {
+        id(generator: "uuid2", type: "uuid-char", length: 36)
+    }
+
+    static constraints = {
+        name(nullable: true)
+    }
+}

--- a/src/groovy/org/grails/plugins/elasticsearch/mapping/ElasticSearchMappingFactory.groovy
+++ b/src/groovy/org/grails/plugins/elasticsearch/mapping/ElasticSearchMappingFactory.groovy
@@ -96,6 +96,8 @@ class ElasticSearchMappingFactory {
 
                     if (idTypeIsMongoObjectId(idType)) {
                         idType = treatValueAsAString(idType)
+                    } else if (idTypeIsUUID(idType)) {
+                        idType = 'string'
                     }
 
                     props.id = defaultDescriptor(idType, 'not_analyzed', true)
@@ -206,6 +208,10 @@ class ElasticSearchMappingFactory {
 
     private static boolean idTypeIsMongoObjectId(String idType) {
         idType.equals('objectId')
+    }
+
+    private static boolean idTypeIsUUID(String idType) {
+        idType.equalsIgnoreCase('uuid')
     }
 
     private static String treatValueAsAString(String idType) {


### PR DESCRIPTION
Similar to the logic for mongo objectId, this uses a String type when a DB is configured with UUIDs as identifiers.