### PR TITLE
Applying defaultExcludedProperties to al searchable classes

### DIFF
--- a/grails-app/domain/test/IncautiousPerson.groovy
+++ b/grails-app/domain/test/IncautiousPerson.groovy
@@ -1,0 +1,15 @@
+package test
+
+/**
+ * Created by @marcos-carceles on 20/05/15.
+ */
+class IncautiousPerson {
+
+    String firstName
+    String lastName
+    String password
+
+    static searchable = {
+        only = ['firstName', 'lastName', 'password']
+    }
+}

--- a/grails-app/domain/test/Person.groovy
+++ b/grails-app/domain/test/Person.groovy
@@ -21,4 +21,8 @@ class Person {
     static searchable = {
         root false
     }
+
+    static constraints = {
+        password nullable: true
+    }
 }

--- a/grails-app/domain/test/Person.groovy
+++ b/grails-app/domain/test/Person.groovy
@@ -7,6 +7,7 @@ class Person {
 
     String firstName
     String lastName
+    String password
 
     List<String> nickNames
 

--- a/src/docs/guide/configuration.gdoc
+++ b/src/docs/guide/configuration.gdoc
@@ -88,8 +88,8 @@ Note : future version of the plugin may change how formats are manipulated.
 
 * @elasticSearch.defaultExcludedProperties@
 List of domain class properties to automatically ignore (will not be indexed) if their name match one of those.
-This will only apply to default-mapped domain class, with the static @searchable@ property set to "true", and will
-not be considered when using closure mapping.
+This will apply to both the default-mapped domain class, with the static @searchable@ property set to "true", and when using closure mapping.
+To override this setting on a specific class, it can be added to the @only@ property of the @searchable@ closure.
 
 * @elasticSearch.disableAutoIndex@
 A boolean determining if the plugin should reflect any database save/update/delete automatically on the indices.

--- a/test/integration/org/grails/plugins/elasticsearch/mapping/SearchableDomainClassMapperIntegrationSpec.groovy
+++ b/test/integration/org/grails/plugins/elasticsearch/mapping/SearchableDomainClassMapperIntegrationSpec.groovy
@@ -1,0 +1,32 @@
+package org.grails.plugins.elasticsearch.mapping
+
+import grails.test.spock.IntegrationSpec
+import org.grails.plugins.elasticsearch.ElasticSearchContextHolder
+import test.Person
+
+/**
+ * Created by @marcos-carceles on 20/05/15.
+ */
+class SearchableDomainClassMapperIntegrationSpec extends IntegrationSpec {
+
+    ElasticSearchContextHolder elasticSearchContextHolder
+
+    def "elasticSearch.defaultExcludedProperties are not mapped"() {
+        expect:
+        elasticSearchContextHolder.config.defaultExcludedProperties.contains('password')
+        Person.searchable instanceof Closure
+
+        when:
+        SearchableClassMapping personMapping = elasticSearchContextHolder.getMappingContextByType(Person)
+
+        then:
+        !personMapping.propertiesMapping*.grailsProperty*.name.contains("password")
+
+        when:
+        SearchableClassMapping incautiousMapping = elasticSearchContextHolder.getMappingContextByType(Person)
+
+        then:
+        !incautiousMapping.propertiesMapping*.grailsProperty*.name.containsAll(["firstName","lastName","password"])
+
+    }
+}


### PR DESCRIPTION
 - defaultExcludedProperties applies to closure in addition to static `searchable=true`
 - can override with `only` property
 - tests
 - updated documentation

@noamt. In a project with a large number of classes (as ours) it is tedious an error prone having to exclude certain properties across all classes. We found that adding this to our own fork of the plugin made our lifes lot easier.