### PR TITLE
Add support for mapping transient collections

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -1,4 +1,4 @@
 #Grails Metadata file
-#Tue Apr 21 20:14:27 CST 2015
-app.grails.version=2.4.4
+#Thu Oct 29 21:44:06 CST 2015
+app.grails.version=2.5.0
 app.name=elasticsearch

--- a/application.properties
+++ b/application.properties
@@ -1,4 +1,4 @@
 #Grails Metadata file
 #Thu Oct 29 21:44:06 CST 2015
-app.grails.version=2.5.0
+app.grails.version=2.4.4
 app.name=elasticsearch

--- a/grails-app/domain/test/transients/Fan.groovy
+++ b/grails-app/domain/test/transients/Fan.groovy
@@ -1,0 +1,14 @@
+package test.transients
+
+/**
+ *
+ * @author Nick
+ */
+class Fan {
+	
+	String name
+	
+	static searchable = true
+	
+}
+

--- a/grails-app/domain/test/transients/Player.groovy
+++ b/grails-app/domain/test/transients/Player.groovy
@@ -1,0 +1,14 @@
+package test.transients
+
+/**
+ *
+ * @author Nick
+ */
+class Player {
+	
+	String name
+	
+	static searchable = true
+	
+}
+

--- a/grails-app/domain/test/transients/Team.groovy
+++ b/grails-app/domain/test/transients/Team.groovy
@@ -1,0 +1,31 @@
+package test.transients
+
+/**
+ *
+ * @author Nick
+ */
+class Team {
+	
+	String name
+	String strip
+	
+	static hasMany = [players:Player, fans:Fan]
+	
+	static searchable = {
+		only = ["players", "name"]
+		players component: true
+		fans reference: true
+	}
+	
+	static transients = ["players", "fans"]
+	
+	def getPlayers() { 
+		return Player.findAll()
+	}
+	
+	def getFans() { 
+		return Fan.findAll()
+	}
+	
+}
+

--- a/src/groovy/org/grails/plugins/elasticsearch/mapping/ElasticSearchMappingFactory.groovy
+++ b/src/groovy/org/grails/plugins/elasticsearch/mapping/ElasticSearchMappingFactory.groovy
@@ -90,7 +90,7 @@ class ElasticSearchMappingFactory {
                         props = [:]
                         propOptions.properties = props
                     }
-                    GrailsDomainClass referencedDomainClass = scpm.grailsProperty.getReferencedDomainClass()
+                    GrailsDomainClass referencedDomainClass = scpm.grailsProperty.getReferencedDomainClass() ?: scpm.getComponentPropertyMapping().domainClass
                     GrailsDomainClassProperty idProperty = referencedDomainClass.getPropertyByName('id')
                     String idType = idProperty.getTypePropertyName()
 

--- a/src/groovy/org/grails/plugins/elasticsearch/mapping/SearchableClassMappingConfigurator.groovy
+++ b/src/groovy/org/grails/plugins/elasticsearch/mapping/SearchableClassMappingConfigurator.groovy
@@ -66,9 +66,16 @@ class SearchableClassMappingConfigurator {
         // Inject cross-referenced component mappings.
         for (SearchableClassMapping scm : mappings) {
             for (SearchableClassPropertyMapping scpm : scm.getPropertiesMapping()) {
-                if (scpm.isComponent()) {
+				LOG.debug("\n\n\n\n")
+				LOG.debug(scpm.dump())
+				LOG.debug("\n\n\n\n")
+                if (scpm.isComponent() && scpm.getGrailsProperty().isPersistent()) {
                     Class<?> componentType = scpm.getGrailsProperty().getReferencedPropertyType()
                     scpm.setComponentPropertyMapping(elasticSearchContext.getMappingContextByType(componentType))
+                } else if(scpm.isComponent()) {
+					Class<?> componentType = scpm.getGrailsProperty().getDomainClass().getRelatedClassType(scpm.propertyName)					
+                    scpm.setComponentPropertyMapping(elasticSearchContext.getMappingContextByType(componentType))
+
                 }
             }
         }


### PR DESCRIPTION
This patch allows for transient collections to be mapped as components/reference for the parent object.

Previously the mapping configurator was unable to determine the type of transient collections.

Referenced in issue #37
