### PR TITLE
Update indexes when associated entities are modified

### DIFF
--- a/src/groovy/org/grails/plugins/elasticsearch/AuditEventListener.groovy
+++ b/src/groovy/org/grails/plugins/elasticsearch/AuditEventListener.groovy
@@ -180,10 +180,10 @@ class AuditEventListener extends AbstractPersistenceEventListener {
      * the hierarchy until it finds the root elements for the search index.
      * <p/>
      *
-     * Note: this relies on the entity being updated must have a back reference to its parent(s).
+     * Note: this relies on the entity being updated having a back reference to its parent(s).
      *
      * @param entity the entity being modified
-     * @return List of zero or more root indexed entities
+     * @return Set of zero or more root indexed entities
      */
     Set getRootIndexedEntity(entity) {
         Set roots = []

--- a/src/groovy/org/grails/plugins/elasticsearch/AuditEventListener.groovy
+++ b/src/groovy/org/grails/plugins/elasticsearch/AuditEventListener.groovy
@@ -128,9 +128,9 @@ class AuditEventListener extends AbstractPersistenceEventListener {
             logger.warn('Received a PostInsertEvent with no entity')
             return
         }
-        if (elasticSearchContextHolder.isRootClass(entity.class)) {
-            pushToIndex(entity)
-        }
+
+        Set roots = getRootIndexedEntity(entity)
+        roots?.each { pushToIndex(it) }
     }
 
     void onPostUpdate(PostUpdateEvent event) {
@@ -139,9 +139,9 @@ class AuditEventListener extends AbstractPersistenceEventListener {
             logger.warn('Received a PostUpdateEvent with no entity')
             return
         }
-        if (elasticSearchContextHolder.isRootClass(entity.class)) {
-            pushToIndex(entity)
-        }
+
+        Set roots = getRootIndexedEntity(entity)
+        roots?.each { pushToIndex(it) }
     }
 
     void onPostDelete(PostDeleteEvent event) {
@@ -150,9 +150,9 @@ class AuditEventListener extends AbstractPersistenceEventListener {
             logger.warn('Received a PostDeleteEvent with no entity')
             return
         }
-        if (elasticSearchContextHolder.isRootClass(entity.class)) {
-            pushToDelete(entity)
-        }
+
+        Set roots = getRootIndexedEntity(entity)
+        roots?.each { pushToDelete(it) }
     }
 
     Map getPendingObjects() {
@@ -169,6 +169,46 @@ class AuditEventListener extends AbstractPersistenceEventListener {
 
     void clearDeletedObjects() {
         deletedObjects.remove()
+    }
+
+    /**
+     * Recursively traverse up the entity hierarchy, using the <code>belongsTo</code> property to find the parent(s) of
+     * the entity being modified.
+     * <p/>
+     *
+     * As long as each parent is 'searchable' (i.e. it has the 'searchable' static member), the code will continue up
+     * the hierarchy until it finds the root elements for the search index.
+     * <p/>
+     *
+     * Note: this relies on the entity being updated must have a back reference to its parent(s).
+     *
+     * @param entity the entity being modified
+     * @return List of zero or more root indexed entities
+     */
+    Set getRootIndexedEntity(entity) {
+        Set roots = []
+
+        if (elasticSearchContextHolder.isRootClass(entity.class)) {
+            roots << entity
+        } else if (entity.hasProperty('searchable') && entity.searchable && entity.hasProperty('belongsTo')) {
+            if (entity.belongsTo instanceof Map) {
+                entity.belongsTo.keySet().each {
+                    def parent = entity[it]
+
+                    roots.addAll(getRootIndexedEntity(parent))
+                }
+            } else if (entity.belongsTo instanceof List) {
+                entity.belongsTo.each { parentType ->
+                    def parent = entity.class.getDeclaredFields().find { it.getType() == parentType }
+
+                    if (parent) {
+                        roots.addAll(getRootIndexedEntity(parent))
+                    }
+                }
+            }
+        }
+
+        roots
     }
 
     private def getEventEntity(AbstractPersistenceEvent event) {

--- a/test/unit/org/grails/plugins/elasticsearch/AuditEventListenerRootIndexSpec.groovy
+++ b/test/unit/org/grails/plugins/elasticsearch/AuditEventListenerRootIndexSpec.groovy
@@ -1,0 +1,133 @@
+package org.grails.plugins.elasticsearch
+
+import spock.lang.Specification
+
+class AuditEventListenerRootIndexSpec extends Specification {
+
+    AuditEventListener listener = new AuditEventListener(null)
+
+    def setup() {
+        listener.elasticSearchContextHolder = Mock(ElasticSearchContextHolder)
+        listener.elasticSearchContextHolder.isRootClass(_) >> { List args ->
+            return args[0] == IndexRootA || args[0] == IndexRootB
+        }
+    }
+
+    def "an entity with root = true should be returned"() {
+        given: "an instance of an entity that is the root of the search index"
+        IndexRootA a = new IndexRootA()
+
+        when: "asked for the root of the search index"
+        Set roots = listener.getRootIndexedEntity(a)
+
+        then: "a should be returned since it is the index root"
+        roots == [a] as Set
+    }
+
+    def "an entity with no searchable property should result in an empty list"() {
+        given: "an instance of an entity that is not searchable"
+        NoParent g = new NoParent()
+
+        when: "asked for the root of the search index"
+        Set roots = listener.getRootIndexedEntity(g)
+
+        then: "an empty list should be returned since the entity is not searchable"
+        roots.isEmpty()
+    }
+
+    def "an entity with no back reference to the parent should result in an empty list"() {
+        given: "an instance of an entity with no back reference to its parent"
+        NoBackReference h = new NoBackReference()
+
+        when: "asked for the root of the search index"
+        Set roots = listener.getRootIndexedEntity(h)
+
+        then: "an empty list should be returned since the entity does not have a back reference to its parent"
+        roots.isEmpty()
+    }
+
+    def "a searchable entity whose parent is the root should result in a list containing the parent"() {
+        given: "an instance of a searchable entity whose parent is the index root"
+        ParentIsRoot d = new ParentIsRoot(a: new IndexRootA())
+
+        when: "asked for the root of the search index"
+        Set roots = listener.getRootIndexedEntity(d)
+
+        then: "a single item list should be returned containing the parent entity"
+        roots[0] == d.a
+    }
+
+    def "a searchable entity with two parents which are index roots should result in a list containing both parents"() {
+        given: "an instance of a searchable entity with two parents which are index roots"
+        TwoParents c = new TwoParents(a: new IndexRootA(), b: new IndexRootB())
+
+        when: "asked for the root of the search index"
+        Set roots = listener.getRootIndexedEntity(c)
+
+        then: "a list containing both parents should be returned"
+        roots[0] == c.a
+        roots[1] == c.b
+    }
+
+    def "a searchable entity whose grandparent is the index root should result in a list containing the grandparent"() {
+        given: "an instance of a searchable entity whose grandparent is the index root"
+        GrandParentIsRoot e = new GrandParentIsRoot(d: new ParentIsRoot(a: new IndexRootA()))
+
+        when: "asked for the root of the search index"
+        Set roots = listener.getRootIndexedEntity(e)
+
+        then: "a single item list should be returned containing the grandparent entity"
+        roots[0] == e.d.a
+    }
+
+    def "a searchable entity whose parent is not searchable should result in an empty list"() {
+        given: "an instance of a searchable entity whose parent is not searchable"
+        NonSearchableParent i = new NonSearchableParent(h: new NoParent())
+
+        when: "asked for the root of the search index"
+        Set roots = listener.getRootIndexedEntity(i)
+
+        then: "an empty list should be returned because the entity is not the root and its parent is not searchable"
+        roots.isEmpty()
+    }
+
+}
+
+class IndexRootA {
+    static searchable = { root = true }
+}
+
+class IndexRootB {
+    static searchable = true
+}
+
+class TwoParents {
+    static searchable = { root = false }
+    IndexRootA a
+    IndexRootB b
+    static belongsTo = [a: IndexRootA, b: IndexRootB]
+}
+
+class ParentIsRoot {
+    static searchable = { root = false }
+    IndexRootA a
+    static belongsTo = [a: IndexRootA]
+}
+
+class GrandParentIsRoot {
+    static searchable = { root = false }
+    ParentIsRoot d
+    static belongsTo = [d: ParentIsRoot]
+}
+
+class NoParent {}
+
+class NoBackReference {
+    static belongsTo = [IndexRootA]
+}
+
+class NonSearchableParent {
+    static searchable = { root = false }
+    NoParent h
+    static belongsTo = [NoParent]
+}


### PR DESCRIPTION
The current version of the plugin (0.0.4.6) does not trigger an index update when modifying/inserting/deleting associated entities (e.g. from a one-to-many relationship).

For example, in the following dummy structure, updating an instance of B directly will not trigger an index update.

```
class A {
  static searchable = {
    children component: true
  }

  String name
  static hasMany = [children: B]
  ...
}

class B {
  static searchable = {
    root = false
  }

  String name
  static belongsTo = [parent: A]
  ...
}

...
A a = new A()
B b1 = new B()
B b2 = new B()
a.children << b1
a.children << b2

a.save() // index updated

a.name = 'bla'
a.save() // index updated

b1.name = 'b1'
b1.save() // index NOT updated
```
This is due to the following code from ```AuditEventListener.groovy```

```
if (elasticSearchContextHolder.isRootClass(entity.class)) {
  pushToIndex(entity)
}
```

The associated entity is not the root class for the index, and so no updates are triggered.

The change in this pull request will traverse the entity relationship hierarchy (as long as the associated entities have back references to their parent) to find the root entity.