### PR TITLE
Correct typo for "node"->"mode" in example 

### DIFF
--- a/src/docs/configuration.adoc
+++ b/src/docs/configuration.adoc
@@ -29,7 +29,7 @@ elasticSearch.client.mode = '<mode>'
 ----
 elasticSearch:
 	client:
-		node: <mode>
+		mode: <mode>
 ----
 
 .Possible values for client node


### PR DESCRIPTION
config variable is supposed to be "mode" but was typo'ed to "node" in the yml example!