### PR TITLE
Plugin incompatible with JDK 7 (Though ElasticSearch is compatible with it)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
     id "com.jfrog.bintray" version "1.2"
 }
 
-version "1.2.0"
+version "1.2.1"
 group "org.grails.plugins"
 
 apply plugin: 'maven-publish'
@@ -33,8 +33,8 @@ ext {
 	elasticsearchVersion = "2.3.3"
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
 
 repositories {
     mavenLocal()


### PR DESCRIPTION
Thanks for the great work! The issue I'm running into is as follows:


ElasticSearch 2.x is compatible with JDK 7, however the plugin complies for JDK 8.
https://www.elastic.co/guide/en/elasticsearch/guide/current/_java_virtual_machine.html
 
When trying to use plugin on JDK 1.7 I get the following exception. This change allows usage with 1.7 1.8 . Upon implementing this this change, tests work with PR.

```
Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [grails.boot.config.GrailsApplicationPostProcessor]: Factory method 'grailsApplicationPostProcessor' threw exception; nested exception is java.lang.UnsupportedClassVersionError: ElasticsearchGrailsPlugin : Unsupported major.minor version 52.0
at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:189)
at org.springframework.beans.factory.support.ConstructorResolver.instantiateUsingFactoryMethod(ConstructorResolver.java:588)
... 44 more
Caused by: java.lang.UnsupportedClassVersionError: ElasticsearchGrailsPlugin : Unsupported major.minor version 52.0
at java.lang.ClassLoader.defineClass(ClassLoader.java:800)
at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
at java.net.URLClassLoader.defineClass(URLClassLoader.java:449)
at java.net.URLClassLoader.access$100(URLClassLoader.java:71)
at java.net.URLClassLoader$1.run(URLClassLoader.java:361)
at java.net.URLClassLoader$1.run(URLClassLoader.java:355)
at java.net.URLClassLoader.findClass(URLClassLoader.java:354)
at java.lang.ClassLoader.loadClass(ClassLoader.java:425)
at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:308)
at java.lang.ClassLoader.loadClass(ClassLoader.java:358)
at org.grails.plugins.CorePluginFinder.attemptCorePluginClassLoad(CorePluginFinder.java:133)
at org.grails.plugins.CorePluginFinder.loadCorePluginsFromResources(CorePluginFinder.java:109)
at org.grails.plugins.CorePluginFinder.getPluginClasses(CorePluginFinder.java:74)
at grails.plugins.DefaultGrailsPluginManager.findCorePlugins(DefaultGrailsPluginManager.java:371)
at grails.plugins.DefaultGrailsPluginManager.attemptLoadPlugins(DefaultGrailsPluginManager.java:330)
at grails.plugins.DefaultGrailsPluginManager.loadPlugins(DefaultGrailsPluginManager.java:240)
at grails.boot.config.GrailsApplicationPostProcessor.initializeGrailsApplication(GrailsApplicationPostProcessor.groovy:84)
at grails.boot.config.GrailsApplicationPostProcessor.setApplicationContext(GrailsApplicationPostProcessor.groovy:208)
at grails.boot.config.GrailsApplicationPostProcessor.<init>(GrailsApplicationPostProcessor.groovy:73)
at grails.boot.config.GrailsAutoConfiguration.grailsApplicationPostProcessor(GrailsAutoConfiguration.groovy:62)
at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:162)
... 45 more
```