### PR TITLE
elasticSearch.index.name config option fix

### DIFF
--- a/src/main/groovy/grails/plugins/elasticsearch/mapping/SearchableClassMapping.groovy
+++ b/src/main/groovy/grails/plugins/elasticsearch/mapping/SearchableClassMapping.groovy
@@ -84,7 +84,7 @@ class SearchableClassMapping implements ElasticSearchConfigAware {
     }
 
     String calculateIndexName() {
-        String name = esConfig?.getProperty('index.name') ?: domainClass.packageName
+        String name = (esConfig?.get('index') as ConfigObject)?.name ?: domainClass.packageName
         if (name == null || name.length() == 0) {
             // index name must be lowercase (org.elasticsearch.indices.InvalidIndexNameException)
             name = domainClass.getPropertyName()


### PR DESCRIPTION
`elasticSearch.index.name` config option is not working in version 1.2.0.
This pull request fixes the problem. 