### PR TITLE
198 - Elasticsearch fails in Grails 3.3.0.m2

### DIFF
--- a/grails-app/init/ElasticsearchBootStrap.groovy
+++ b/grails-app/init/ElasticsearchBootStrap.groovy
@@ -1,10 +1,15 @@
 import grails.plugins.elasticsearch.ElasticSearchBootStrapHelper
+import grails.plugins.elasticsearch.mapping.SearchableClassMappingConfigurator
 
 class ElasticsearchBootStrap {
 
     ElasticSearchBootStrapHelper elasticSearchBootStrapHelper
+    SearchableClassMappingConfigurator searchableClassMappingConfigurator
 
     def init = { servletContext ->
+
+        //Fixes https://github.com/noamt/elasticsearch-grails-plugin/issues/198
+        searchableClassMappingConfigurator.configureAndInstallMappings()
         elasticSearchBootStrapHelper?.bulkIndexOnStartup()
     }
 }

--- a/grails-app/init/ElasticsearchBootStrap.groovy
+++ b/grails-app/init/ElasticsearchBootStrap.groovy
@@ -1,15 +1,21 @@
 import grails.plugins.elasticsearch.ElasticSearchBootStrapHelper
 import grails.plugins.elasticsearch.mapping.SearchableClassMappingConfigurator
+import grails.plugins.elasticsearch.util.DomainDynamicMethodsUtils
+import grails.util.Holders
 
 class ElasticsearchBootStrap {
 
     ElasticSearchBootStrapHelper elasticSearchBootStrapHelper
     SearchableClassMappingConfigurator searchableClassMappingConfigurator
 
+    def grailsApplication
+    def applicationContext
     def init = { servletContext ->
+        grailsApplication = Holders.grailsApplication
+        applicationContext = Holders.applicationContext
 
-        //Fixes https://github.com/noamt/elasticsearch-grails-plugin/issues/198
         searchableClassMappingConfigurator.configureAndInstallMappings()
+        DomainDynamicMethodsUtils.injectDynamicMethods(grailsApplication, applicationContext)
         elasticSearchBootStrapHelper?.bulkIndexOnStartup()
     }
 }

--- a/src/main/groovy/grails/plugins/elasticsearch/ElasticsearchGrailsPlugin.groovy
+++ b/src/main/groovy/grails/plugins/elasticsearch/ElasticsearchGrailsPlugin.groovy
@@ -94,8 +94,6 @@ class ElasticsearchGrailsPlugin extends Plugin {
                 grailsApplication = grailsApplication
                 es = ref('elasticSearchAdminService')
                 mmm = ref('mappingMigrationManager')
-
-                bean.initMethod = 'configureAndInstallMappings'
             }
             domainInstancesRebuilder(DomainClassUnmarshaller) {
                 elasticSearchContextHolder = ref('elasticSearchContextHolder')

--- a/src/main/groovy/grails/plugins/elasticsearch/mapping/ElasticSearchMappingFactory.groovy
+++ b/src/main/groovy/grails/plugins/elasticsearch/mapping/ElasticSearchMappingFactory.groovy
@@ -151,6 +151,12 @@ class ElasticSearchMappingFactory {
 
             //Preprocess collections and arrays to work with it's element types
             Class referencedPropertyType = scpm.grailsProperty.getReferencedPropertyType()
+
+            //referencedPropertyType received null if the propType is long
+            if (referencedPropertyType == null && propType == 'long') {
+                referencedPropertyType = "java.lang.Long"
+            }
+
             if (Collection.isAssignableFrom(referencedPropertyType) || referencedPropertyType.isArray()) {
                 //Handle collections explictly mapped (needed for dealing with transients)
                 if (scpm.grailsProperty.domainClass.associationMap[scpm.grailsProperty.name]) {


### PR DESCRIPTION
This fixes changes the moment when the installation and configuration of mappings is done. Now these processes are done in Bootstrap, after the GORM is initialized. Also there was a problem with properties with type long.