### PR TITLE
Migrated to ElasticSearch 5.3.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 .gradle
 build/
 
+libs
+
 # Log files
 *.log
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ apply plugin: "org.grails.grails-gsp"
 ext {
     grailsVersion = project.grailsVersion
     gradleWrapperVersion = project.gradleWrapperVersion
-    elasticsearchVersion = "2.3.3"
+    elasticsearchVersion = "5.3.3"
 }
 
 sourceCompatibility = 1.7
@@ -66,7 +66,8 @@ sourcesJar {
     exclude "test/**/**"
 }
 
-def elasticsearchVersion = '2.3.3'
+def elasticsearchVersion = '5.3.3'
+def elasticsearchAttachmentsVersion = '2.4.6'
 
 dependencies {
     provided 'org.springframework.boot:spring-boot-starter-logging'
@@ -81,7 +82,12 @@ dependencies {
     compile "org.grails.plugins:cache"
     compile "org.hibernate:hibernate-ehcache"
 
+    compile "org.apache.logging.log4j:log4j-api:2.7"
+    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.7'
+
     compile "org.elasticsearch:elasticsearch:${elasticsearchVersion}"
+    compile group: 'org.elasticsearch.client', name: 'transport', version: elasticsearchVersion
+
 
     testRuntime 'com.spatial4j:spatial4j:0.4.1'
     testCompile 'com.vividsolutions:jts:1.13'
@@ -93,7 +99,9 @@ dependencies {
     provided "org.grails:grails-plugin-services"
     provided "org.grails:grails-plugin-domain-class"
 
-    compile "org.elasticsearch.plugin:mapper-attachments:${elasticsearchVersion}"
+    //compile "org.elasticsearch.plugin:mapper-attachments:${elasticsearchAttachmentsVersion}"
+    provided group: 'org.elasticsearch', name: 'elasticsearch-mapper-attachments', version: '3.1.2'
+
 }
 
 task wrapper(type: Wrapper) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import de.undercouch.gradle.tasks.download.Download
+
 buildscript {
     ext {
         grailsVersion = project.grailsVersion
@@ -17,6 +19,7 @@ buildscript {
 plugins {
     id "com.jfrog.bintray" version "1.2"
     id 'com.jfrog.artifactory' version '4.0.0'
+    id "de.undercouch.download" version "3.2.0"
 }
 
 version "1.2.1"
@@ -67,7 +70,6 @@ sourcesJar {
 }
 
 def elasticsearchVersion = '5.3.3'
-def elasticsearchAttachmentsVersion = '2.4.6'
 
 dependencies {
     provided 'org.springframework.boot:spring-boot-starter-logging'
@@ -100,8 +102,24 @@ dependencies {
     provided "org.grails:grails-plugin-domain-class"
 
     //compile "org.elasticsearch.plugin:mapper-attachments:${elasticsearchAttachmentsVersion}"
-    provided group: 'org.elasticsearch', name: 'elasticsearch-mapper-attachments', version: '3.1.2'
+    compile fileTree(dir: "libs/elasticsearch", include: '*.jar')
 
+}
+
+task downloadAttachmentsPlugin(type: Download) {
+    src "https://artifacts.elastic.co/downloads/elasticsearch-plugins/mapper-attachments/mapper-attachments-${elasticsearchVersion}.zip"
+    dest "libs/mapper-attachments-${elasticsearchVersion}.zip"
+    overwrite true
+    onlyIfNewer true
+}
+
+task downloadAndUnzipAttachmentsPlugin(dependsOn: downloadAttachmentsPlugin, type: Copy){
+    from zipTree(downloadAttachmentsPlugin.dest)
+    into 'libs/'
+}
+
+compileJava{
+    dependsOn downloadAndUnzipAttachmentsPlugin
 }
 
 task wrapper(type: Wrapper) {

--- a/build.gradle
+++ b/build.gradle
@@ -113,13 +113,22 @@ task downloadAttachmentsPlugin(type: Download) {
     onlyIfNewer true
 }
 
-task downloadAndUnzipAttachmentsPlugin(dependsOn: downloadAttachmentsPlugin, type: Copy){
-    from zipTree(downloadAttachmentsPlugin.dest)
-    into 'libs/'
+task downloadAndUnzipAttachmentsPlugin(dependsOn: downloadAttachmentsPlugin) {
+    doLast {
+        copy {
+            from zipTree(downloadAttachmentsPlugin.dest)
+            into 'libs/'
+        }
+        delete 'libs/elasticsearch/commons-codec-1.10.jar'
+    }
 }
 
 compileJava{
     dependsOn downloadAndUnzipAttachmentsPlugin
+}
+
+task cleanLibsDir(type: Delete) {
+    delete fileTree(dir: 'libs')
 }
 
 task wrapper(type: Wrapper) {
@@ -132,6 +141,7 @@ check.doLast {
 
 clean.doLast {
     cleanDataDir.execute()
+    cleanLibsDir.execute()
 }
 
 task cleanDataDir(type: Delete) {

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -87,8 +87,6 @@ environments:
             bulkIndexOnStartup: true
     test:
         elasticSearch:
-            cluster:
-              name: 'local.test.es.cluster'
             client:
                 mode: local
                 transport.sniff: false

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -87,9 +87,11 @@ environments:
             bulkIndexOnStartup: true
     test:
         elasticSearch:
+            cluster:
+              name: 'local.test.es.cluster'
             client:
                 mode: local
-                transport.sniff: true
+                transport.sniff: false
             datastoreImpl: hibernateDatastore
             index:
                 store.type: simplefs

--- a/grails-app/domain/test/File.groovy
+++ b/grails-app/domain/test/File.groovy
@@ -6,7 +6,7 @@ class File {
     String attachment // base64 encoded file contents
 
     static searchable = {
-        attachment attachment: true
+        //attachment attachment: false
     }
 
     static constraints = {

--- a/grails-app/domain/test/File.groovy
+++ b/grails-app/domain/test/File.groovy
@@ -6,7 +6,7 @@ class File {
     String attachment // base64 encoded file contents
 
     static searchable = {
-        //attachment attachment: true
+        attachment attachment: true
     }
 
     static constraints = {

--- a/grails-app/domain/test/File.groovy
+++ b/grails-app/domain/test/File.groovy
@@ -6,7 +6,7 @@ class File {
     String attachment // base64 encoded file contents
 
     static searchable = {
-        //attachment attachment: false
+        //attachment attachment: true
     }
 
     static constraints = {

--- a/grails-app/domain/test/Product.groovy
+++ b/grails-app/domain/test/Product.groovy
@@ -3,16 +3,18 @@ package test
 import org.grails.web.json.JSONObject
 
 class Product {
-    String name
+    String productName
     String description = "A description of a product"
     Float price = 1.00
     Date date
     JSONObject json
 
-    static searchable = true
+    static searchable = {
+        productName fielddata: true
+    }
 
     static constraints = {
-        name blank: false
+        productName blank: false
         description nullable: true
         price nullable: true
         date nullable: true

--- a/grails-app/services/grails/plugins/elasticsearch/ElasticSearchService.groovy
+++ b/grails-app/services/grails/plugins/elasticsearch/ElasticSearchService.groovy
@@ -438,7 +438,10 @@ class ElasticSearchService implements GrailsApplicationAware {
     }
 
 	SearchSourceBuilder setFilterInSource(SearchSourceBuilder source, Closure filter, Map params = [:]){
-		source.postFilter(new GXContentBuilder().buildAsBytes(filter))
+    def filterBytes = new GXContentBuilder().buildAsBytes(filter)
+    XContentParser parser = createParser(JsonXContent.jsonXContent, filterBytes)
+    def filterBuilder = parseInnerQueryBuilder(parser)
+		source.postFilter(filterBuilder)
 	}
 
 	SearchSourceBuilder setFilterInSource(SearchSourceBuilder source, QueryBuilder filter, Map params = [:]){

--- a/grails-app/services/grails/plugins/elasticsearch/ElasticSearchService.groovy
+++ b/grails-app/services/grails/plugins/elasticsearch/ElasticSearchService.groovy
@@ -343,7 +343,9 @@ class ElasticSearchService implements GrailsApplicationAware {
      */
     private SearchRequest buildCountRequest(query, Map params) {
         params['size'] = 0
-        return buildSearchRequest(query, params)
+        def request = buildSearchRequest(query, null, params)
+        request.source().size(0)
+        return request
     }
 
     /**
@@ -520,17 +522,8 @@ class ElasticSearchService implements GrailsApplicationAware {
      * @return Integer The number of hits for the query
      */
     Integer count(SearchRequest request, Map params) {
-        resolveIndicesAndTypes(request, params)
-        elasticSearchHelper.withElasticSearch { Client client ->
-            LOG.debug 'Executing count request.'
-            def response = client.count(request).actionGet()
-            LOG.debug 'Completed count request.'
-            def result = response.count ?: 0
-
-            LOG.debug "${result} hit(s) matched the specified query."
-
-            result
-        }
+        def result = search(request, params)
+        result.total
     }
     /**
      * Sets the indices & types properties on SearchRequest & CountRequest

--- a/grails-app/services/grails/plugins/elasticsearch/ElasticSearchService.groovy
+++ b/grails-app/services/grails/plugins/elasticsearch/ElasticSearchService.groovy
@@ -20,23 +20,36 @@ import grails.core.support.GrailsApplicationAware
 import grails.plugins.elasticsearch.index.IndexRequestQueue
 import grails.plugins.elasticsearch.mapping.SearchableClassMapping
 import grails.plugins.elasticsearch.util.GXContentBuilder
-import org.elasticsearch.action.count.CountRequest
 import org.elasticsearch.action.search.SearchRequest
 import org.elasticsearch.action.search.SearchType
-import org.elasticsearch.action.support.QuerySourceBuilder
 import org.elasticsearch.client.Client
+import org.elasticsearch.cluster.ClusterModule
+import org.elasticsearch.common.bytes.BytesArray
+import org.elasticsearch.common.bytes.BytesReference
+import org.elasticsearch.common.io.stream.InputStreamStreamInput
+import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry
+import org.elasticsearch.common.io.stream.StreamInput
+import org.elasticsearch.common.settings.Settings
+import org.elasticsearch.common.xcontent.NamedXContentRegistry
+import org.elasticsearch.common.xcontent.XContent
+import org.elasticsearch.common.xcontent.XContentParser
+import org.elasticsearch.common.xcontent.json.JsonXContent
 import org.elasticsearch.index.query.QueryBuilder
 import org.elasticsearch.index.query.QueryStringQueryBuilder
 import org.elasticsearch.search.SearchHit
+import org.elasticsearch.search.SearchModule
 import org.elasticsearch.search.builder.SearchSourceBuilder
-import org.elasticsearch.search.highlight.HighlightBuilder
+import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder
 import org.elasticsearch.search.sort.SortBuilder
 import org.elasticsearch.search.sort.SortOrder
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
+import static grails.plugins.elasticsearch.util.AbstractQueryBuilderParser.parseInnerQueryBuilder
 import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery
-import static org.elasticsearch.index.query.QueryStringQueryBuilder.Operator
+
+import org.elasticsearch.index.query.Operator
 
 class ElasticSearchService implements GrailsApplicationAware {
     static final Logger LOG = LoggerFactory.getLogger(this)
@@ -119,7 +132,7 @@ class ElasticSearchService implements GrailsApplicationAware {
      * @return An Integer representing the number of hits for the query
      */
     Integer countHits(String query, Map params = [:]) {
-        CountRequest request = buildCountRequest(query, params)
+        SearchRequest request = buildCountRequest(query, params)
         count(request, params)
     }
 
@@ -131,7 +144,7 @@ class ElasticSearchService implements GrailsApplicationAware {
      * @return An Integer representing the number of hits for the query
      */
     Integer countHits(Map params, Closure query) {
-        CountRequest request = buildCountRequest(query, params)
+        SearchRequest request = buildCountRequest(query, params)
         count(request, params)
     }
 
@@ -328,22 +341,9 @@ class ElasticSearchService implements GrailsApplicationAware {
      * @param params
      * @return
      */
-    private CountRequest buildCountRequest(query, Map params) {
-        CountRequest request = new CountRequest()
-
-        // Handle the query, can either be a closure or a string
-        if (query instanceof Closure) {
-            request.source(new GXContentBuilder().buildAsBytes(query))
-        } else {
-            Operator defaultOperator = params['default_operator'] ?: Operator.AND
-            QueryStringQueryBuilder builder = queryStringQuery(query).defaultOperator(defaultOperator)
-            if (params.analyzer) {
-                builder.analyzer(params.analyzer)
-            }
-            request.source(new QuerySourceBuilder().setQuery(builder))
-        }
-
-        request
+    private SearchRequest buildCountRequest(query, Map params) {
+        params['size'] = 0
+        return buildSearchRequest(query, params)
     }
 
     /**
@@ -412,11 +412,29 @@ class ElasticSearchService implements GrailsApplicationAware {
     }
 
     SearchSourceBuilder setQueryInSource(SearchSourceBuilder source, Closure query, Map params = [:]) {
-        source.query(new GXContentBuilder().buildAsBytes(query))
+        def queryBytes = new GXContentBuilder().buildAsBytes(query)
+        XContentParser parser = createParser(JsonXContent.jsonXContent, queryBytes)
+        def queryBuilder = parseInnerQueryBuilder(parser)
+
+        source.query(queryBuilder)
     }
 
     SearchSourceBuilder setQueryInSource(SearchSourceBuilder source, QueryBuilder query, Map params = [:]) {
         source.query(query)
+    }
+
+    private static SearchModule searchModule = null;
+    private static NamedXContentRegistry ContentRegistry = null;
+    private static NamedXContentRegistry getXContentRegistry() {
+        if(ContentRegistry == null){
+            searchModule = new SearchModule(Settings.EMPTY, false, Collections.emptyList())
+            ContentRegistry = searchModule.namedXContents;
+        }
+        return ContentRegistry;
+    }
+
+    private static XContentParser createParser(XContent xContent, byte[] data) throws IOException {
+        return xContent.createParser(getXContentRegistry(), data);
     }
 
 	SearchSourceBuilder setFilterInSource(SearchSourceBuilder source, Closure filter, Map params = [:]){
@@ -498,7 +516,7 @@ class ElasticSearchService implements GrailsApplicationAware {
      * @param params
      * @return Integer The number of hits for the query
      */
-    Integer count(CountRequest request, Map params) {
+    Integer count(SearchRequest request, Map params) {
         resolveIndicesAndTypes(request, params)
         elasticSearchHelper.withElasticSearch { Client client ->
             LOG.debug 'Executing count request.'
@@ -519,7 +537,7 @@ class ElasticSearchService implements GrailsApplicationAware {
      * @return
      */
     private resolveIndicesAndTypes(request, Map params) {
-        assert request instanceof SearchRequest || request instanceof CountRequest
+        assert request instanceof SearchRequest
 
         // Handle the indices.
         if (params.indices) {

--- a/src/integration-test/groovy/grails/plugins/elasticsearch/ElasticSearchServiceIntegrationSpec.groovy
+++ b/src/integration-test/groovy/grails/plugins/elasticsearch/ElasticSearchServiceIntegrationSpec.groovy
@@ -599,7 +599,7 @@ class ElasticSearchServiceIntegrationSpec extends Specification {
         def sortResults = result.sort.(searchResults[0].id).collect {(it as BigDecimal).setScale(4, RoundingMode.HALF_UP) }
 
         then: 'all geo points in the search radius are found'
-        sortResults == [2.5383]
+        sortResults == [2.5401]
     }
 
     void 'Component as an inner object'() {

--- a/src/integration-test/groovy/grails/plugins/elasticsearch/ElasticSearchServiceIntegrationSpec.groovy
+++ b/src/integration-test/groovy/grails/plugins/elasticsearch/ElasticSearchServiceIntegrationSpec.groovy
@@ -577,8 +577,7 @@ class ElasticSearchServiceIntegrationSpec extends Specification {
 
         when: 'a geo distance search is sorted by distance'
 
-        def sortBuilder = SortBuilders.geoDistanceSort('location').
-                point(48.141, 11.57).
+        def sortBuilder = SortBuilders.geoDistanceSort('location', 48.141d, 11.57d).
                 unit(DistanceUnit.KILOMETERS).
                 order(SortOrder.ASC)
 

--- a/src/integration-test/groovy/grails/plugins/elasticsearch/ElasticSearchServiceIntegrationSpec.groovy
+++ b/src/integration-test/groovy/grails/plugins/elasticsearch/ElasticSearchServiceIntegrationSpec.groovy
@@ -63,16 +63,16 @@ class ElasticSearchServiceIntegrationSpec extends Specification {
     }
 
     void setupData() {
-        Product product01 = new Product(name: 'horst', price: 3.95)
+        Product product01 = new Product(productName: 'horst', price: 3.95)
         product01.save(failOnError: true)
 
-        Product product02 = new Product(name: 'hobbit', price: 5.99)
+        Product product02 = new Product(productName: 'hobbit', price: 5.99)
         product02.save(failOnError: true)
 
-        Product product03 = new Product(name: 'best', price: 10.99)
+        Product product03 = new Product(productName: 'best', price: 10.99)
         product03.save(failOnError: true)
 
-        Product product04 = new Product(name: 'high and supreme', price: 45.50)
+        Product product04 = new Product(productName: 'high and supreme', price: 45.50)
         product04.save(failOnError: true)
         [
                 [lat: 48.13, lon: 11.60, name: '81667'],
@@ -92,7 +92,7 @@ class ElasticSearchServiceIntegrationSpec extends Specification {
 
     void 'Index and un-index a domain object'() {
         given:
-        def product = new Product(name: 'myTestProduct')
+        def product = new Product(productName: 'myTestProduct')
         product.save(failOnError: true)
 
         when:
@@ -111,7 +111,7 @@ class ElasticSearchServiceIntegrationSpec extends Specification {
 
     void 'Indexing the same object multiple times updates the corresponding ES entry'() {
         given:
-        def product = new Product(name: 'myTestProduct')
+        def product = new Product(productName: 'myTestProduct')
         product.save(failOnError: true)
 
         when:
@@ -122,7 +122,7 @@ class ElasticSearchServiceIntegrationSpec extends Specification {
         elasticSearchService.search('myTestProduct', [indices: Product, types: Product]).total == 1
 
         when:
-        product.name = 'newProductName'
+        product.productName = 'newProductName'
         product.save(failOnError: true)
         elasticSearchService.index(product)
         elasticSearchAdminService.refresh()
@@ -131,16 +131,16 @@ class ElasticSearchServiceIntegrationSpec extends Specification {
         elasticSearchService.search('myTestProduct', [indices: Product, types: Product]).total == 0
 
         and:
-        def result = elasticSearchService.search(product.name, [indices: Product, types: Product])
+        def result = elasticSearchService.search(product.productName, [indices: Product, types: Product])
         result.total == 1
         List<Product> searchResults = result.searchResults
-        searchResults[0].name == product.name
+        searchResults[0].productName == product.productName
 
     }
 
     void 'a json object value should be marshalled and de-marshalled correctly'() {
         given:
-        def product = new Product(name: 'product with json value')
+        def product = new Product(productName: 'product with json value')
         product.json = new JSONObject("""
 {
     "test": {
@@ -155,12 +155,12 @@ class ElasticSearchServiceIntegrationSpec extends Specification {
         elasticSearchAdminService.refresh()
 
         when:
-        def result = elasticSearchService.search(product.name, [indices: Product, types: Product])
+        def result = elasticSearchService.search(product.productName, [indices: Product, types: Product])
 
         then:
         result.total == 1
         List<Product> searchResults = result.searchResults
-        searchResults[0].name == product.name
+        searchResults[0].productName == product.productName
     }
 
     void 'should marshal the alias field and unmarshal correctly (ignore alias)'() {
@@ -191,7 +191,7 @@ class ElasticSearchServiceIntegrationSpec extends Specification {
         Date date = new Date()
         given:
         def product = new Product(
-                name: 'product with date value',
+                productName: 'product with date value',
                 date: date
         ).save(failOnError: true)
 
@@ -199,12 +199,12 @@ class ElasticSearchServiceIntegrationSpec extends Specification {
         elasticSearchAdminService.refresh()
 
         when:
-        def result = elasticSearchService.search(product.name, [indices: Product, types: Product])
+        def result = elasticSearchService.search(product.productName, [indices: Product, types: Product])
 
         then:
         result.total == 1
         List<Product> searchResults = result.searchResults
-        searchResults[0].name == product.name
+        searchResults[0].productName == product.productName
         searchResults[0].date == product.date
     }
 
@@ -294,13 +294,13 @@ class ElasticSearchServiceIntegrationSpec extends Specification {
 
     void 'searching with filtered query'() {
         given: 'some products'
-        def wurmProduct = new Product(name: 'wurm', price: 2.00)
+        def wurmProduct = new Product(productName: 'wurm', price: 2.00)
         wurmProduct.save(failOnError: true)
 
-        def hansProduct = new Product(name: 'hans', price: 0.5)
+        def hansProduct = new Product(productName: 'hans', price: 0.5)
         hansProduct.save(failOnError: true)
 
-        def fooProduct = new Product(name: 'foo', price: 5.0)
+        def fooProduct = new Product(productName: 'foo', price: 5.0)
         fooProduct.save(failOnError: true)
 
         elasticSearchService.index(wurmProduct, hansProduct, fooProduct)
@@ -312,7 +312,7 @@ class ElasticSearchServiceIntegrationSpec extends Specification {
         then: "the result should be product 'wurm'"
         result.total == 1
         List<Product> searchResults = result.searchResults
-        searchResults[0].name == wurmProduct.name
+        searchResults[0].productName == wurmProduct.productName
     }
 
     void 'searching with a FilterBuilder filter and a Closure query'() {
@@ -323,7 +323,7 @@ class ElasticSearchServiceIntegrationSpec extends Specification {
         then: "the result should be product 'wurm'"
         result.total == 1
         List<Product> searchResults = result.searchResults
-        searchResults[0].name == "wurm"
+        searchResults[0].productName == "wurm"
     }
 
     void 'searching with a FilterBuilder filter and a QueryBuilder query'() {
@@ -334,7 +334,7 @@ class ElasticSearchServiceIntegrationSpec extends Specification {
         then: "the result should be product 'wurm'"
         result.total == 1
         List<Product> searchResults = result.searchResults
-        searchResults[0].name == "wurm"
+        searchResults[0].productName == "wurm"
     }
 
     void 'searching with wildcards in query at first position'() {
@@ -344,13 +344,13 @@ class ElasticSearchServiceIntegrationSpec extends Specification {
         elasticSearchAdminService.refresh()
         Map params = [indices: Product, types: Product]
         def result = elasticSearchService.search({
-            wildcard(name: '*st')
+            wildcard(productName: '*st')
         }, params)
 
         then: 'the result should contain 2 products'
         result.total == 2
         List<Product> searchResults = result.searchResults
-        searchResults*.name.containsAll('best', 'horst')
+        searchResults*.productName.containsAll('best', 'horst')
     }
 
     void 'searching with wildcards in query at last position'() {
@@ -360,13 +360,13 @@ class ElasticSearchServiceIntegrationSpec extends Specification {
 
         Map params2 = [indices: Product, types: Product]
         def result2 = elasticSearchService.search({
-            wildcard(name: 'ho*')
+            wildcard(productName: 'ho*')
         }, params2)
 
         then: 'the result should return 2 products'
         result2.total == 2
         List<Product> searchResults2 = result2.searchResults
-        searchResults2*.name.containsAll('horst', 'hobbit')
+        searchResults2*.productName.containsAll('horst', 'hobbit')
     }
 
     void 'searching with wildcards in query in between position'() {
@@ -376,19 +376,19 @@ class ElasticSearchServiceIntegrationSpec extends Specification {
         elasticSearchAdminService.refresh()
         Map params3 = [indices: Product, types: Product]
         def result3 = elasticSearchService.search({
-            wildcard(name: 's*eme')
+            wildcard(productName: 's*eme')
         }, params3)
 
         then: 'the result should return 1 product'
         result3.total == 1
         List<Product> searchResults3 = result3.searchResults
-        searchResults3[0].name == 'high and supreme'
+        searchResults3[0].productName == 'high and supreme'
     }
 
     void 'searching for special characters in data pool'() {
 
         given: 'some products'
-        def product01 = new Product(name: 'ästhätik', price: 3.95)
+        def product01 = new Product(productName: 'ästhätik', price: 3.95)
         product01.save(failOnError: true)
 
         elasticSearchService.index(product01)
@@ -397,13 +397,13 @@ class ElasticSearchServiceIntegrationSpec extends Specification {
         when: "search for 'a umlaut' "
 
         def result = elasticSearchService.search({
-            match(name: 'ästhätik')
+            match(productName: 'ästhätik')
         })
 
         then: 'the result should contain 1 product'
         result.total == 1
         List<Product> searchResults = result.searchResults
-        searchResults[0].name == product01.name
+        searchResults[0].productName == product01.productName
     }
 
     void 'searching for features of the parent element from the actual element'() {
@@ -414,7 +414,7 @@ class ElasticSearchServiceIntegrationSpec extends Specification {
         parentParentElement.save(failOnError: true)
         def parentElement = new Department(name: 'Elternelement', numberOfProducts: 4, store: parentParentElement)
         parentElement.save(failOnError: true)
-        def childElement = new Product(name: 'Kindelement', price: 5.00)
+        def childElement = new Product(productName: 'Kindelement', price: 5.00)
         childElement.save(failOnError: true)
 
         elasticSearchService.index(parentParentElement, parentElement, childElement)
@@ -435,22 +435,22 @@ class ElasticSearchServiceIntegrationSpec extends Specification {
         given: 'a bunch of products'
         def product
         10.times {
-            product = new Product(name: "Produkt${it}", price: it).save(failOnError: true, flush: true)
+            product = new Product(productName: "Produkt${it}", price: it).save(failOnError: true, flush: true)
             elasticSearchService.index(product)
         }
         elasticSearchAdminService.refresh()
 
         when: 'a search is performed'
-        def params = [from: 3, size: 2, indices: Product, types: Product, sort: 'name']
+        def params = [from: 3, size: 2, indices: Product, types: Product, sort: 'productName']
         def query = {
-            wildcard(name: 'produkt*')
+            wildcard(productName: 'produkt*')
         }
         def result = elasticSearchService.search(query, params)
 
         then: 'the correct result-part is returned'
         result.total == 10
         result.searchResults.size() == 2
-        result.searchResults*.name == ['Produkt3', 'Produkt4']
+        result.searchResults*.productName == ['Produkt3', 'Produkt4']
     }
 
     void 'Multiple sorting through search results'() {
@@ -458,59 +458,59 @@ class ElasticSearchServiceIntegrationSpec extends Specification {
         def product
         2.times { int i ->
             2.times { int k ->
-                product = new Product(name: "Yogurt$i", price: k).save(failOnError: true, flush: true)
+                product = new Product(productName: "Yogurt$i", price: k).save(failOnError: true, flush: true)
                 elasticSearchService.index(product)
             }
         }
         elasticSearchAdminService.refresh()
 
         when: 'a search is performed'
-        def sort1 = new FieldSortBuilder('name').order(SortOrder.ASC)
+        def sort1 = new FieldSortBuilder('productName').order(SortOrder.ASC)
         def sort2 = new FieldSortBuilder('price').order(SortOrder.DESC)
         def params = [indices: Product, types: Product, sort: [sort1, sort2]]
         def query = {
-            wildcard(name: 'yogurt*')
+            wildcard(productName: 'yogurt*')
         }
         def result = elasticSearchService.search(query, params)
 
         then: 'the correct result-part is returned'
         result.searchResults.size() == 4
-        result.searchResults*.name == ['Yogurt0', 'Yogurt0', 'Yogurt1', 'Yogurt1']
+        result.searchResults*.productName == ['Yogurt0', 'Yogurt0', 'Yogurt1', 'Yogurt1']
         result.searchResults*.price == [1, 0, 1, 0]
 
         when: 'another search is performed'
-        sort1 = new FieldSortBuilder('name').order(SortOrder.DESC)
+        sort1 = new FieldSortBuilder('productName').order(SortOrder.DESC)
         sort2 = new FieldSortBuilder('price').order(SortOrder.ASC)
         params = [indices: Product, types: Product, sort: [sort1, sort2]]
         query = {
-            wildcard(name: 'yogurt*')
+            wildcard(productName: 'yogurt*')
         }
         result = elasticSearchService.search(query, params)
 
         then: 'the correct result-part is returned'
         result.total == 4
         result.searchResults.size() == 4
-        result.searchResults*.name == ['Yogurt1', 'Yogurt1', 'Yogurt0', 'Yogurt0']
+        result.searchResults*.productName == ['Yogurt1', 'Yogurt1', 'Yogurt0', 'Yogurt0']
         result.searchResults*.price == [0, 1, 0, 1]
     }
 
     void 'A search with Uppercase Characters should return appropriate results'() {
         given: 'a product with an uppercase name'
-        def product = new Product(name: 'Großer Kasten', price: 0.85).save(failOnError: true, flush: true)
+        def product = new Product(productName: 'Großer Kasten', price: 0.85).save(failOnError: true, flush: true)
         elasticSearchService.index(product)
         elasticSearchAdminService.refresh()
 
         when: 'a search is performed'
         def params = [indices: Product, types: Product]
         def query = {
-            match('name': 'Großer')
+            match('productName': 'Großer')
         }
         def result = elasticSearchService.search(query, params)
 
         then: 'the correct result-part is returned'
         result.total == 1
         result.searchResults.size() == 1
-        result.searchResults*.name == ['Großer Kasten']
+        result.searchResults*.productName == ['Großer Kasten']
     }
 
     void 'a geo distance search finds geo points at varying distances'() {
@@ -551,21 +551,21 @@ class ElasticSearchServiceIntegrationSpec extends Specification {
 
     void 'A search with lowercase Characters should return appropriate results'() {
         given: 'a product with a lowercase name'
-        def product = new Product(name: 'KLeiner kasten', price: 0.45).save(failOnError: true, flush: true)
+        def product = new Product(productName: 'KLeiner kasten', price: 0.45).save(failOnError: true, flush: true)
         elasticSearchService.index(product)
         elasticSearchAdminService.refresh()
 
         when: 'a search is performed'
         def params = [indices: Product, types: Product]
         def query = {
-            wildcard('name': 'klein*')
+            wildcard('productName': 'klein*')
         }
         def result = elasticSearchService.search(query, params)
 
         then: 'the correct result-part is returned'
         result.total == 1
         result.searchResults.size() == 1
-        result.searchResults*.name == ['KLeiner kasten']
+        result.searchResults*.productName == ['KLeiner kasten']
     }
 
     void 'the distances are returned'() {
@@ -692,12 +692,12 @@ class ElasticSearchServiceIntegrationSpec extends Specification {
 
     void 'Use an aggregation'() {
         given:
-        def jim = new Product(name: 'jim', price: 1.99).save(flush: true, failOnError: true)
-        def xlJim = new Product(name: 'xl-jim', price: 5.99).save(flush: true, failOnError: true)
+        def jim = new Product(productName: 'jim', price: 1.99).save(flush: true, failOnError: true)
+        def xlJim = new Product(productName: 'xl-jim', price: 5.99).save(flush: true, failOnError: true)
         elasticSearchService.index(jim, xlJim)
         elasticSearchAdminService.refresh()
 
-        def query = QueryBuilders.matchQuery('name', 'jim')
+        def query = QueryBuilders.matchQuery('productName', 'jim')
         SearchRequest request = new SearchRequest()
         request.searchType SearchType.DFS_QUERY_THEN_FETCH
 

--- a/src/integration-test/groovy/grails/plugins/elasticsearch/ElasticSearchServiceIntegrationSpec.groovy
+++ b/src/integration-test/groovy/grails/plugins/elasticsearch/ElasticSearchServiceIntegrationSpec.groovy
@@ -422,7 +422,7 @@ class ElasticSearchServiceIntegrationSpec extends Specification {
 
         when:
         def result = elasticSearchService.search(
-                QueryBuilders.hasParentQuery('store', QueryBuilders.matchQuery('owner', 'Horst')),
+                QueryBuilders.hasParentQuery('store', QueryBuilders.matchQuery('owner', 'Horst'), false),
                 QueryBuilders.matchAllQuery(),
                 [indices: Department, types: Department]
         )

--- a/src/integration-test/groovy/grails/plugins/elasticsearch/mapping/ElasticSearchMappingFactorySpec.groovy
+++ b/src/integration-test/groovy/grails/plugins/elasticsearch/mapping/ElasticSearchMappingFactorySpec.groovy
@@ -51,7 +51,7 @@ class ElasticSearchMappingFactorySpec extends Specification {
         where:
         clazz    | property          || expectedType
 
-        Building | 'name'            || 'string'
+        Building | 'name'            || 'text'
         Building | 'date'            || 'date'
         Building | 'location'        || 'geo_point'
 
@@ -60,11 +60,11 @@ class ElasticSearchMappingFactorySpec extends Specification {
 
         Catalog  | 'pages'           || 'object'
 
-        Person   | 'fullName'        || 'string'
-        Person   | 'nickNames'       || 'string'
+        Person   | 'fullName'        || 'text'
+        Person   | 'nickNames'       || 'text'
 
-        Palette  | 'colors'          || 'string'
-        Palette  | 'complementaries' || 'string'
+        Palette  | 'colors'          || 'text'
+        Palette  | 'complementaries' || 'text'
 
         Anagram  | 'length'          || 'integer'
         Anagram  | 'palindrome'      || 'boolean'

--- a/src/main/groovy/grails/plugins/elasticsearch/ClientNodeFactoryBean.groovy
+++ b/src/main/groovy/grails/plugins/elasticsearch/ClientNodeFactoryBean.groovy
@@ -20,8 +20,8 @@ import org.elasticsearch.Version
 import org.elasticsearch.client.transport.TransportClient
 import org.elasticsearch.common.settings.Settings
 import org.elasticsearch.common.transport.InetSocketTransportAddress
+import org.elasticsearch.mapper.attachments.MapperAttachmentsPlugin
 import org.elasticsearch.node.Node
-import org.elasticsearch.plugin.mapper.attachments.MapperAttachmentsPlugin
 import org.elasticsearch.plugins.Plugin
 import org.elasticsearch.transport.client.PreBuiltTransportClient
 import org.slf4j.Logger

--- a/src/main/groovy/grails/plugins/elasticsearch/conversion/unmarshall/DomainClassUnmarshaller.groovy
+++ b/src/main/groovy/grails/plugins/elasticsearch/conversion/unmarshall/DomainClassUnmarshaller.groovy
@@ -248,7 +248,7 @@ class DomainClassUnmarshaller implements DataBinder {
 
                 parseResult = null
             } else if (scpm.grailsProperty.type == Date && null != propertyValue) {
-                parseResult = XContentBuilder.defaultDatePrinter.parseDateTime(propertyValue).toDate()
+                parseResult = XContentBuilder.DEFAULT_DATE_PRINTER.parseDateTime(propertyValue).toDate()
             }
         }
 

--- a/src/main/groovy/grails/plugins/elasticsearch/index/IndexRequestQueue.groovy
+++ b/src/main/groovy/grails/plugins/elasticsearch/index/IndexRequestQueue.groovy
@@ -287,7 +287,7 @@ class IndexRequestQueue {
             }
         }
 
-        void onFailure(Throwable e) {
+        void onFailure(Exception e) {
             // Everything failed. Re-push all.
             LOG.error('Bulk request failure', e)
             def remainingAttempts = attempts.getAndDecrement()

--- a/src/main/groovy/grails/plugins/elasticsearch/mapping/ElasticSearchMappingFactory.groovy
+++ b/src/main/groovy/grails/plugins/elasticsearch/mapping/ElasticSearchMappingFactory.groovy
@@ -136,6 +136,9 @@ class ElasticSearchMappingFactory {
             if (propType == 'object' && scpm.component && !scpm.innerComponent) {
                 propOptions.type = 'nested'
             }
+            if (propType == 'text' && scpm.fieldDataEnabled){
+                propOptions.fielddata = true
+            }
             elasticTypeMappingProperties.put(scpm.getPropertyName(), propOptions)
         }
         elasticTypeMappingProperties

--- a/src/main/groovy/grails/plugins/elasticsearch/mapping/ElasticSearchMappingFactory.groovy
+++ b/src/main/groovy/grails/plugins/elasticsearch/mapping/ElasticSearchMappingFactory.groovy
@@ -161,12 +161,12 @@ class ElasticSearchMappingFactory {
                 if (referencedPropertyType.isArray()) {
                     referencedPropertyType = referencedPropertyType.getComponentType()
                 }
-                String basicType = getTypeSimpleName(referencedPropertyType)
+                String basicType = getTypeSimpleName(referencedPropertyType, scpm)
                 if (SUPPORTED_FORMAT.contains(basicType)) {
                     propType = basicType
                 }
-            } else if (!SUPPORTED_FORMAT.contains(propType) && SUPPORTED_FORMAT.contains(getTypeSimpleName(referencedPropertyType))) {
-                propType = getTypeSimpleName(referencedPropertyType)
+            } else if (!SUPPORTED_FORMAT.contains(propType) && SUPPORTED_FORMAT.contains(getTypeSimpleName(referencedPropertyType, scpm))) {
+                propType = getTypeSimpleName(referencedPropertyType, scpm)
             }
 
             //Handle unsupported types
@@ -206,9 +206,12 @@ class ElasticSearchMappingFactory {
         propType
     }
 
-    private static String getTypeSimpleName(Class type) {
+    private static String getTypeSimpleName(Class type, SearchableClassPropertyMapping scpm) {
         String name = ClassUtils.getShortName(type).toLowerCase(Locale.ENGLISH)
-        return name == 'string' ? 'text' : name
+        if(name == 'string'){
+            name = scpm.analyzed ? 'text' : 'keyword'
+        }
+        return name
     }
 
     private static boolean idTypeIsMongoObjectId(String idType) {

--- a/src/main/groovy/grails/plugins/elasticsearch/mapping/SearchableClassMappingConfigurator.groovy
+++ b/src/main/groovy/grails/plugins/elasticsearch/mapping/SearchableClassMappingConfigurator.groovy
@@ -23,7 +23,7 @@ import org.grails.core.artefact.DomainClassArtefactHandler
 import grails.core.GrailsApplication
 import grails.core.GrailsClass
 import grails.core.GrailsDomainClass
-import org.elasticsearch.index.mapper.MergeMappingException
+import org.elasticsearch.indices.InvalidIndexTemplateException
 import org.elasticsearch.transport.RemoteTransportException
 import grails.plugins.elasticsearch.ElasticSearchAdminService
 import grails.plugins.elasticsearch.ElasticSearchContextHolder
@@ -143,7 +143,7 @@ class SearchableClassMappingConfigurator implements ElasticSearchConfigAware {
                     } catch (IllegalArgumentException e) {
                         LOG.warn("Could not install mapping ${scm.indexName}/${scm.elasticTypeName} due to ${e.message}, migrations needed")
                         mappingConflicts << new MappingConflict(scm: scm, exception: e)
-                    } catch (MergeMappingException e) {
+                    } catch (InvalidIndexTemplateException e) {
                         LOG.warn("Could not install mapping ${scm.indexName}/${scm.elasticTypeName} due to ${e.message}, migrations needed")
                         mappingConflicts << new MappingConflict(scm: scm, exception: e)
                     }
@@ -195,7 +195,9 @@ class SearchableClassMappingConfigurator implements ElasticSearchConfigAware {
             LOG.debug("Retrieved index settings")
             if (indexDefaults != null) {
                 for (Map.Entry<String, Object> entry : indexDefaults.entrySet()) {
-                    indexSettings.put("index." + entry.getKey(), entry.getValue())
+                    String key = entry.getKey();
+                    if(key == 'numberOfReplicas') key = 'number_of_replicas'
+                    indexSettings.put("index." + key, entry.getValue())
                 }
             }
         }

--- a/src/main/groovy/grails/plugins/elasticsearch/mapping/SearchableClassPropertyMapping.groovy
+++ b/src/main/groovy/grails/plugins/elasticsearch/mapping/SearchableClassPropertyMapping.groovy
@@ -25,7 +25,7 @@ import groovy.transform.CompileStatic
 @CompileStatic
 class SearchableClassPropertyMapping {
 
-    private static final Set<String> SEARCHABLE_MAPPING_OPTIONS = ['boost', 'index', 'analyzer'] as Set<String>
+    private static final Set<String> SEARCHABLE_MAPPING_OPTIONS = ['boost', 'index', 'analyzer', 'fielddata'] as Set<String>
     private static final Set<String> SEARCHABLE_SPECIAL_MAPPING_OPTIONS =
             ['component', 'converter', 'reference', 'excludeFromAll', 'maxDepth', 'multi_field', 'parent', 'geoPoint',
              'alias', 'dynamic', 'attachment'] as Set<String>
@@ -96,6 +96,10 @@ class SearchableClassPropertyMapping {
 
     boolean isDynamic() {
         specialMappingAttributes.dynamic
+    }
+
+    boolean isFieldDataEnabled() {
+        !!mappingAttributes.fielddata
     }
 
     /**

--- a/src/main/groovy/grails/plugins/elasticsearch/util/AbstractQueryBuilderParser.groovy
+++ b/src/main/groovy/grails/plugins/elasticsearch/util/AbstractQueryBuilderParser.groovy
@@ -1,0 +1,58 @@
+package grails.plugins.elasticsearch.util
+
+import org.elasticsearch.common.ParsingException
+import org.elasticsearch.common.xcontent.NamedXContentRegistry
+import org.elasticsearch.common.xcontent.XContentLocation
+import org.elasticsearch.common.xcontent.XContentParser
+import org.elasticsearch.index.query.QueryBuilder
+import org.elasticsearch.index.query.QueryParseContext
+
+/**
+ * Created by ehauske on 2/08/17.
+ */
+class AbstractQueryBuilderParser {
+
+  /**
+   * Parses a query excluding the query element that wraps it
+   */
+  public static QueryBuilder parseInnerQueryBuilder(XContentParser parser) throws IOException {
+    if (parser.currentToken() != XContentParser.Token.START_OBJECT) {
+      if (parser.nextToken() != XContentParser.Token.START_OBJECT) {
+        throw new ParsingException(parser.getTokenLocation(), "[_na] query malformed, must start with start_object");
+      }
+    }
+    if (parser.nextToken() == XContentParser.Token.END_OBJECT) {
+      // we encountered '{}' for a query clause, it used to be supported, deprecated in 5.0 and removed in 6.0
+      throw new IllegalArgumentException("query malformed, empty clause found at [" + parser.getTokenLocation() +"]");
+    }
+    if (parser.currentToken() != XContentParser.Token.FIELD_NAME) {
+      throw new ParsingException(parser.getTokenLocation(), "[_na] query malformed, no field after start_object");
+    }
+    String queryName = parser.currentName();
+    // move to the next START_OBJECT
+    if (parser.nextToken() != XContentParser.Token.START_OBJECT) {
+      throw new ParsingException(parser.getTokenLocation(), "[" + queryName + "] query malformed, no start_object after query name");
+    }
+    QueryBuilder result;
+    try {
+      def object = parser.namedObject(Optional.class, queryName, new QueryParseContext(parser))
+      result = object.get();
+    } catch (NamedXContentRegistry.UnknownNamedObjectException e) {
+      // Preserve the error message from 5.0 until we have a compellingly better message so we don't break BWC.
+      // This intentionally doesn't include the causing exception because that'd change the "root_cause" of any unknown query errors
+      throw new ParsingException(new XContentLocation(e.getLineNumber(), e.getColumnNumber()),
+        "no [query] registered for [" + e.getName() + "]");
+    }
+    //end_object of the specific query (e.g. match, multi_match etc.) element
+    if (parser.currentToken() != XContentParser.Token.END_OBJECT) {
+      throw new ParsingException(parser.getTokenLocation(),
+        "[" + queryName + "] malformed query, expected [END_OBJECT] but found [" + parser.currentToken() + "]");
+    }
+    //end_object of the query object
+    if (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+      throw new ParsingException(parser.getTokenLocation(),
+        "[" + queryName + "] malformed query, expected [END_OBJECT] but found [" + parser.currentToken() + "]");
+    }
+    return result;
+  }
+}

--- a/src/main/groovy/grails/plugins/elasticsearch/util/GXContentBuilder.groovy
+++ b/src/main/groovy/grails/plugins/elasticsearch/util/GXContentBuilder.groovy
@@ -19,6 +19,7 @@
 
 package grails.plugins.elasticsearch.util
 
+import org.elasticsearch.common.bytes.BytesReference
 import org.elasticsearch.common.xcontent.XContentBuilder
 import org.elasticsearch.common.xcontent.XContentFactory
 import org.elasticsearch.common.xcontent.XContentType
@@ -59,7 +60,8 @@ class GXContentBuilder extends GroovyObjectSupport {
         XContentBuilder builder = XContentFactory.contentBuilder(contentType)
         def json = build(c)
         builder.map(json)
-        return builder.bytes().toBytes()
+        def bytes = builder.bytes()
+        return BytesReference.toBytes(bytes)
     }
 
     private buildRoot(Closure c) {


### PR DESCRIPTION
Changes:

- Migrated dependency to ES 5.3.3
- Changed data types 'string' to 'text' and 'keyword' with sensible defaults
- **BREAKING CHANGE:** text properties need to add `fielddata: true` to support sort since it is disabled by default. This one is the reason to change version to 2.0.0
- Parsed query and filter from bytes [(1)](https://github.com/noamt/elasticsearch-grails-plugin/compare/master...erichmx:2.0.0?expand=1#diff-db739c40b01f8c5a63f8bf58dce43f72R416). Open to suggestions on how to improve this. Also I'm not sure if it would affect using plugins that extend the queries.
- Renamed Product.name to Product.productName to add `fielddata: true` without affecting other mappings. All types in the tests are created in the same index and therefore all properties "name" must have the same mapping.
- Changed how `count` are requested, now it has to be with a `SearchRequest` with `size: 0`
- For some reason the distance is being calculated slightly different and I had to update the test named: `a geo distance search is sorted by distance`


